### PR TITLE
feat: 노션 heading_4 블록 h4 렌더링 지원

### DIFF
--- a/docs/superpowers/plans/2026-07-10-notion-h4-heading.md
+++ b/docs/superpowers/plans/2026-07-10-notion-h4-heading.md
@@ -1,0 +1,128 @@
+# Notion heading_4 블록 지원 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Notion 2026-03에 추가된 `heading_4` 블록을 블로그·북 상세 페이지에서 `<h4>`로 렌더링한다.
+
+**Architecture:** `notion-to-md@3.1.9`가 모르는 `heading_4` 타입에 커스텀 트랜스포머를 등록해 표준 마크다운 `#### `를 방출한다. 순수 마크다운이므로 센티넬 마커·렌더러 오버라이드·TOC 변경이 전혀 필요 없다 — react-markdown 기본 h4 렌더 + 기존 `prose.css` 스타일 + `NotionToc`의 DOM 수집이 그대로 동작한다.
+
+**Tech Stack:** notion-to-md 커스텀 트랜스포머, react-markdown (변경 없음)
+
+## Global Constraints
+
+- 테스트 러너 없음 — 검증은 `pnpm exec tsc --noEmit` + `pnpm lint` + 브라우저 수동 확인 + `pnpm build` (CLAUDE.md)
+- worktree에서 `pnpm lint` 실패 시 M-13 우회: `.eslintrc.json`에 임시 `"root": true` 추가 → lint → `git checkout -- .eslintrc.json`
+- 커밋은 commit-message 스킬 형식: 한국어 제목, 마침표 없음, scope 없음, 본문 한 줄 40자 이내
+- 의존성 추가·업그레이드 금지 (notion-to-md v4, @notionhq/client 업그레이드는 범위 밖)
+- 주석은 한국어, 식별자는 영어
+- 센티넬 마커 미사용 — `####`는 표준 마크다운 (마커 철칙 해당 없음)
+
+---
+
+### Task 1: spec·plan 문서 커밋
+
+**Files:**
+
+- Create(이미 작성됨): `docs/superpowers/specs/2026-07-10-notion-h4-heading-design.md`
+- Create(이미 작성됨): `docs/superpowers/plans/2026-07-10-notion-h4-heading.md`
+
+**Interfaces:**
+
+- Consumes: 없음
+- Produces: 이후 Task의 근거 문서 (feature 브랜치 첫 커밋)
+
+- [ ] **Step 1: 두 문서를 feature 브랜치에 커밋**
+
+```bash
+git add docs/superpowers/specs/2026-07-10-notion-h4-heading-design.md \
+        docs/superpowers/plans/2026-07-10-notion-h4-heading.md
+git commit -m "docs: 노션 h4 헤딩 지원 설계·계획 문서 추가"
+```
+
+### Task 2: heading_4 커스텀 트랜스포머
+
+**Files:**
+
+- Modify: `src/libs/notion/transformers.ts` (embed 트랜스포머 블록 뒤, `getPageContentAsMarkdown` 앞에 추가)
+
+**Interfaces:**
+
+- Consumes: 같은 파일의 `richTextToMarkdown(richText: RichTextItemResponse[]): string` 헬퍼, `n2m` 싱글턴 (`./client`)
+- Produces: `heading_4` 블록 → `#### <인라인 서식 보존 텍스트>` 마크다운. 렌더러는 별도 소비 코드 없음 (react-markdown 기본 동작)
+
+- [ ] **Step 1: 트랜스포머 추가**
+
+`transformers.ts`의 embed 트랜스포머(`n2m.setCustomTransformer("embed", ...)`) 블록 바로 아래에 추가:
+
+```ts
+// h4 헤딩 블록 변환 — heading_4는 Notion 2026-03 추가 블록이라
+// SDK 타입 union과 notion-to-md 기본 switch에 없어 커스텀 트랜스포머로 지원
+// (미등록 시 default 분기로 떨어져 헤딩이 일반 문단처럼 출력됨)
+n2m.setCustomTransformer("heading_4", (async (block: BlockObjectResponse) => {
+  const headingBlock = block as unknown as { heading_4: { rich_text: RichTextItemResponse[] } };
+  const text = richTextToMarkdown(headingBlock.heading_4?.rich_text ?? []);
+
+  // 빈 헤딩은 블록 자체를 생략 (n2m의 빈 문자열 반환 관행과 동일)
+  if (!text) return "";
+
+  return `#### ${text}`;
+}) as CustomTransformer);
+```
+
+주의: `BlockObjectResponse`, `RichTextItemResponse`, `CustomTransformer`는 이미 import되어 있음 — import 추가 불필요.
+
+- [ ] **Step 2: 타입체크·린트**
+
+Run: `pnpm exec tsc --noEmit && pnpm lint`
+Expected: 둘 다 통과 (worktree에서 lint 실패 시 M-13 우회 적용)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/libs/notion/transformers.ts
+git commit -m "feat: 노션 heading_4 블록 h4 렌더링 지원" -m "notion-to-md가 모르는 2026-03 신규 블록이
+일반 문단으로 강등되던 문제를
+커스텀 트랜스포머로 해결"
+```
+
+### Task 3: 엔드투엔드 수동 검증
+
+**Files:** 코드 변경 없음 (검증 전용)
+
+**Interfaces:**
+
+- Consumes: Task 2의 트랜스포머, Notion 테스트 포스트(status=Upload)
+- Produces: PR 첨부용 스크린샷 + 검증 결과
+
+- [ ] **Step 1: Notion 테스트 포스트에 h4 케이스 3종 삽입**
+
+status=Upload인 테스트 포스트에: ① 일반 h4 ② 볼드·링크 포함 h4 ③ 빈 텍스트 h4
+
+- [ ] **Step 2: dev 서버에서 확인**
+
+Run: `pnpm dev` 후 해당 포스트 접속. 체크리스트:
+
+- h4가 `<h4>` 태그 + prose 스타일로 렌더 (평문 문단 아님)
+- 볼드·링크 등 인라인 서식 보존
+- 빈 h4는 화면에 아무것도 남기지 않음
+- NotionToc 목차에 level 4로 표시되고 앵커 클릭 시 스크롤
+- 다크모드 토글 정상, 375px 뷰포트 정상, 콘솔 hydration 경고 0건
+- 일반 본문 텍스트 오탐 없음
+- 북 상세(`/book/[slug]`)에서도 h4 렌더 확인 (북 DB에 h4 넣을 수 없으면 트랜스포머 공유 사실을 PR 본문에 근거로 기재)
+
+- [ ] **Step 3: 프로덕션 빌드**
+
+Run: `pnpm build`
+Expected: 성공
+
+- [ ] **Step 4: 스크린샷 캡처**
+
+라이트/다크 각 1장 — PR 본문 첨부용 (UI 변경이므로 필수)
+
+---
+
+## Self-Review
+
+- 스펙 커버리지: 결정 1·3(트랜스포머+서식 보존)→Task 2, 결정 2·4·5(무변경 확인)→Task 3 체크리스트, 에러 처리(빈 rich_text)→Task 2 코드 + Task 3 케이스 ③, 테스트·검증 절→Task 2 Step 2 + Task 3. 범위 밖 항목은 어떤 Task도 건드리지 않음. 갭 없음.
+- 플레이스홀더: 없음 (모든 코드·명령·커밋 메시지 명시).
+- 타입 일관성: `richTextToMarkdown` 시그니처는 기존 파일 정의와 일치, 신규 심볼 없음.

--- a/docs/superpowers/plans/2026-07-10-notion-h4-heading.md
+++ b/docs/superpowers/plans/2026-07-10-notion-h4-heading.md
@@ -17,6 +17,15 @@
 - 주석은 한국어, 식별자는 영어
 - 센티넬 마커 미사용 — `####`는 표준 마크다운 (마커 철칙 해당 없음)
 
+## File Structure
+
+| 파일                                                            | 변경   | 책임                                            |
+| --------------------------------------------------------------- | ------ | ----------------------------------------------- |
+| `src/libs/notion/transformers.ts`                               | 수정   | heading_4 커스텀 트랜스포머 (마크다운 방출)     |
+| `docs/superpowers/specs/2026-07-10-notion-h4-heading-design.md` | 생성   | 설계 문서                                       |
+| `docs/superpowers/plans/2026-07-10-notion-h4-heading.md`        | 생성   | 구현 계획 (이 문서)                             |
+| 렌더러·스타일·TOC·마커 상수                                     | 무변경 | 표준 마크다운이라 기존 파이프라인이 그대로 동작 |
+
 ---
 
 ### Task 1: spec·plan 문서 커밋
@@ -47,7 +56,7 @@ git commit -m "docs: 노션 h4 헤딩 지원 설계·계획 문서 추가"
 
 **Interfaces:**
 
-- Consumes: 같은 파일의 `richTextToMarkdown(richText: RichTextItemResponse[]): string` 헬퍼, `n2m` 싱글턴 (`./client`)
+- Consumes: 같은 파일의 `richTextToMarkdown(richText: RichTextItemResponse[]): string` · `getChildrenAsMarkdown(blockId: string): Promise<string>` 헬퍼, `n2m` 싱글턴 (`./client`)
 - Produces: `heading_4` 블록 → `#### <인라인 서식 보존 텍스트>` 마크다운. 렌더러는 별도 소비 코드 없음 (react-markdown 기본 동작)
 
 - [ ] **Step 1: 트랜스포머 추가**
@@ -60,14 +69,21 @@ git commit -m "docs: 노션 h4 헤딩 지원 설계·계획 문서 추가"
 // (미등록 시 default 분기로 떨어져 헤딩이 일반 문단처럼 출력됨)
 n2m.setCustomTransformer("heading_4", (async (block: BlockObjectResponse) => {
   const headingBlock = block as unknown as { heading_4: { rich_text: RichTextItemResponse[] } };
-  const text = richTextToMarkdown(headingBlock.heading_4?.rich_text ?? []);
+  // 공백만 있는 헤딩이 빈 <h4>로 남지 않도록 trim
+  const text = richTextToMarkdown(headingBlock.heading_4.rich_text).trim();
+  // 커스텀 트랜스포머를 등록하면 n2m의 children 재귀가 꺼지므로(blocksToMarkdown의
+  // 재귀 가드) 토글 h4의 하위 블록은 callout과 같은 방식으로 직접 이어 붙인다
+  const children = block.has_children ? await getChildrenAsMarkdown(block.id) : "";
 
-  // 빈 헤딩은 블록 자체를 생략 (n2m의 빈 문자열 반환 관행과 동일)
-  if (!text) return "";
+  // 제목이 비면 헤딩은 생략하되 하위 블록 내용은 보존
+  if (!text) return children;
 
-  return `#### ${text}`;
+  return children ? `#### ${text}\n\n${children}` : `#### ${text}`;
 }) as CustomTransformer);
 ```
+
+> 최초 계획은 children 미처리였으나 셀프리뷰에서 회귀(토글 h4 하위 블록 소실)로
+> 판정되어 스펙 결정 4와 함께 갱신됨. 근거는 스펙의 결정 사항 4 참조.
 
 주의: `BlockObjectResponse`, `RichTextItemResponse`, `CustomTransformer`는 이미 import되어 있음 — import 추가 불필요.
 

--- a/docs/superpowers/specs/2026-07-10-notion-h4-heading-design.md
+++ b/docs/superpowers/specs/2026-07-10-notion-h4-heading-design.md
@@ -26,12 +26,21 @@ rich_text만 추출해 **일반 문단처럼 출력**한다. 그 결과 Notion �
    기본으로 `<h4>`를 렌더한다. 마커 상수·렌더러 오버라이드·`<p>` 언랩 분기가
    모두 불필요하다.
 3. **인라인 서식 보존.** 기존 헬퍼 `richTextToMarkdown`을 재사용해 볼드·링크·
-   인라인 수식 등 annotation을 유지한다.
-4. **렌더러·스타일·TOC는 무변경.** `prose.css`에 `.prose h4` 스타일이 이미 있고,
+   인라인 수식 등 annotation을 유지한다. 공백만 있는 헤딩이 빈 `<h4>`로 남지
+   않도록 텍스트를 trim한다.
+4. **토글 h4의 하위 블록을 보존한다.** n2m은 커스텀 트랜스포머가 등록된 타입의
+   children 재귀를 건너뛴다(`blocksToMarkdown`의 재귀 가드, notion-to-md.js:202).
+   등록 전에는 토글 h4의 하위 블록이 이 재귀로 렌더되고 있었으므로, 트랜스포머가
+   children을 처리하지 않으면 **기존 대비 콘텐츠 소실 회귀**가 된다. callout
+   트랜스포머와 동일하게 `getChildrenAsMarkdown`으로 하위 블록을 이어 붙인다.
+   (셀프리뷰에서 발견 — 최초 설계의 "토글 children 미지원" 결정을 뒤집음.
+   미지원 근거였던 "h1~3과 대칭" 전제가 틀렸다: h1~3은 커스텀 트랜스포머가
+   아니어서 children이 렌더된다.)
+5. **렌더러·스타일·TOC는 무변경.** `prose.css`에 `.prose h4` 스타일이 이미 있고,
    tailwind typography 설정의 scroll-margin이 h4를 포함하며, `NotionToc`는 DOM에서
    `h1~h6`를 수집하므로 자동 반영된다. 트랜스포머는 블로그(`NotionPostLayout`)와
    북(`BookPostLayout`) 양쪽이 공유하므로 한 번의 수정으로 둘 다 해결된다.
-5. **rehypeSanitize 스키마 무변경.** 기본 스키마가 h1~h6을 허용한다.
+6. **rehypeSanitize 스키마 무변경.** 기본 스키마가 h1~h6을 허용한다.
 
 ## 데이터 흐름
 
@@ -55,8 +64,8 @@ Notion heading_4 블록
 
 ## 에러 처리 · 폴백
 
-- `rich_text`가 빈 배열이면 빈 헤딩 텍스트가 되므로 트랜스포머가 빈 문자열을
-  반환해 블록을 생략한다 (n2m의 빈 반환 관행과 동일).
+- `rich_text`가 비었거나 공백뿐이면 헤딩은 생략하되, 토글 하위 블록이 있으면
+  그 내용만 보존해 반환한다 (콘텐츠 소실 방지).
 - SDK 타입 union에 `heading_4`가 없으므로 appsuit-fe 선례처럼 명시적 캐스팅으로
   접근하고, 캐스팅 사유를 주석으로 남긴다.
 
@@ -76,8 +85,6 @@ Notion heading_4 블록
 ## 범위 밖 (YAGNI)
 
 - **heading_5 / heading_6** — Notion에 존재하지 않는 블록. 추가하지 않는다.
-- **토글 h4의 children 렌더링** — 기존 h1~3 토글 헤딩도 children을 렌더하지
-  않는다. 대칭성을 유지하고 확장하지 않는다 (사용자 확인 완료).
 - **notion-to-md v4 업그레이드** — 베타이고 API가 전면 개편됨. 별도 작업.
 - **@notionhq/client 업그레이드** — heading_4 타입이 포함된 SDK가 나와도 이번
   작업에서는 올리지 않는다 (의존성 변경은 에스컬레이션 대상).

--- a/docs/superpowers/specs/2026-07-10-notion-h4-heading-design.md
+++ b/docs/superpowers/specs/2026-07-10-notion-h4-heading-design.md
@@ -1,0 +1,83 @@
+# Notion heading_4 블록 지원 — 설계
+
+날짜: 2026-07-10
+관련 작업: 노션 h4 헤딩 블록을 블로그에서 렌더링
+
+## 배경
+
+Notion이 2026-03 업데이트로 `heading_4` 블록을 추가했다. 이 레포의 마크다운 변환기
+`notion-to-md@3.1.9`는 `heading_1`~`heading_3`만 알고, 미지 타입은 default 분기에서
+rich_text만 추출해 **일반 문단처럼 출력**한다. 그 결과 Notion 본문의 h4 헤딩이
+블로그에서 헤딩 시맨틱을 잃고 평문으로 렌더된다.
+
+참고 선례: `~/appsuit-fe/apps/home/src/lib/cms-notion/blocks.ts`가 같은 문제를
+겪었다. 고정된 SDK 타입 union에 `heading_4`가 없어 switch로 잡히지 않으므로,
+`type` 문자열 검사 + 캐스팅으로 level 4 헤딩으로 정규화하고 TOC에 포함시켰다.
+이 레포는 파이프라인 구조가 다르므로(블록 정규화 대신 n2m 커스텀 트랜스포머)
+원리만 가져온다.
+
+## 결정 사항
+
+1. **수정 지점은 `src/libs/notion/transformers.ts` 한 곳.**
+   `n2m.setCustomTransformer("heading_4", ...)`로 `#### <텍스트>`를 방출한다.
+   n2m은 커스텀 트랜스포머를 타입 문자열 키로 조회하므로 SDK union에 없는
+   타입에도 동작함을 소스(`notion-to-md.js:230`)에서 확인했다.
+2. **센티넬 마커를 쓰지 않는다.** `####`는 순수 마크다운이라 react-markdown이
+   기본으로 `<h4>`를 렌더한다. 마커 상수·렌더러 오버라이드·`<p>` 언랩 분기가
+   모두 불필요하다.
+3. **인라인 서식 보존.** 기존 헬퍼 `richTextToMarkdown`을 재사용해 볼드·링크·
+   인라인 수식 등 annotation을 유지한다.
+4. **렌더러·스타일·TOC는 무변경.** `prose.css`에 `.prose h4` 스타일이 이미 있고,
+   tailwind typography 설정의 scroll-margin이 h4를 포함하며, `NotionToc`는 DOM에서
+   `h1~h6`를 수집하므로 자동 반영된다. 트랜스포머는 블로그(`NotionPostLayout`)와
+   북(`BookPostLayout`) 양쪽이 공유하므로 한 번의 수정으로 둘 다 해결된다.
+5. **rehypeSanitize 스키마 무변경.** 기본 스키마가 h1~h6을 허용한다.
+
+## 데이터 흐름
+
+```
+Notion heading_4 블록
+ → transformers.ts 커스텀 트랜스포머: "#### " + richTextToMarkdown(rich_text)
+ → 마크다운 문자열 (순수 표준 문법, 마커 없음)
+ → react-markdown 기본 렌더링 → <h4>
+ → prose.css의 .prose h4 스타일 적용, NotionToc가 DOM에서 자동 수집
+```
+
+## 구성 요소
+
+| 구성 요소                              | 변경 | 내용                                       |
+| -------------------------------------- | ---- | ------------------------------------------ |
+| `src/libs/notion/transformers.ts`      | 수정 | `heading_4` 커스텀 트랜스포머 추가 (~10줄) |
+| 마커 상수 (`data/constants/notion.ts`) | 없음 | 마커 미사용                                |
+| `NotionPostLayout` / `BookPostLayout`  | 없음 | react-markdown 기본 h4 렌더                |
+| `prose.css` / tailwind typography      | 없음 | h4 스타일 기존재                           |
+| `NotionToc`                            | 없음 | h1~h6 DOM 수집으로 자동 포함               |
+
+## 에러 처리 · 폴백
+
+- `rich_text`가 빈 배열이면 빈 헤딩 텍스트가 되므로 트랜스포머가 빈 문자열을
+  반환해 블록을 생략한다 (n2m의 빈 반환 관행과 동일).
+- SDK 타입 union에 `heading_4`가 없으므로 appsuit-fe 선례처럼 명시적 캐스팅으로
+  접근하고, 캐스팅 사유를 주석으로 남긴다.
+
+## 테스트 · 검증
+
+테스트 러너가 없으므로 CLAUDE.md 공통 게이트를 따른다:
+
+1. `pnpm exec tsc --noEmit` + `pnpm lint` (worktree면 M-13 우회)
+2. Notion 테스트 포스트(status=Upload)에 h4 블록(일반 / 인라인 서식 포함 / 빈
+   텍스트) 삽입 후 `pnpm dev`에서:
+   - h4가 `<h4>`로 렌더되고 prose 스타일 적용
+   - NotionToc에 level 4로 표시, 앵커 스크롤 동작
+   - 다크모드·375px 정상, hydration 경고 0건
+   - 블로그·북 상세 양쪽 확인
+3. `pnpm build` 성공
+
+## 범위 밖 (YAGNI)
+
+- **heading_5 / heading_6** — Notion에 존재하지 않는 블록. 추가하지 않는다.
+- **토글 h4의 children 렌더링** — 기존 h1~3 토글 헤딩도 children을 렌더하지
+  않는다. 대칭성을 유지하고 확장하지 않는다 (사용자 확인 완료).
+- **notion-to-md v4 업그레이드** — 베타이고 API가 전면 개편됨. 별도 작업.
+- **@notionhq/client 업그레이드** — heading_4 타입이 포함된 SDK가 나와도 이번
+  작업에서는 올리지 않는다 (의존성 변경은 에스컬레이션 대상).

--- a/src/libs/notion/transformers.ts
+++ b/src/libs/notion/transformers.ts
@@ -218,9 +218,10 @@ n2m.setCustomTransformer("bookmark", (async (block: BlockObjectResponse) => {
 // SDK 타입 union과 notion-to-md 기본 switch에 없어 커스텀 트랜스포머로 지원
 // (미등록 시 default 분기로 떨어져 헤딩이 일반 문단처럼 출력됨)
 n2m.setCustomTransformer("heading_4", (async (block: BlockObjectResponse) => {
-  const headingBlock = block as unknown as { heading_4: { rich_text: RichTextItemResponse[] } };
+  const headingBlock = block as unknown as { heading_4?: { rich_text?: RichTextItemResponse[] } };
+  // SDK 타입 검증이 없는 단언 캐스트라 이웃 트랜스포머와 달리 방어적으로 접근
   // 공백만 있는 헤딩이 빈 <h4>로 남지 않도록 trim
-  const text = richTextToMarkdown(headingBlock.heading_4.rich_text).trim();
+  const text = richTextToMarkdown(headingBlock.heading_4?.rich_text ?? []).trim();
   // 커스텀 트랜스포머를 등록하면 n2m의 children 재귀가 꺼지므로(blocksToMarkdown의
   // 재귀 가드) 토글 h4의 하위 블록은 callout과 같은 방식으로 직접 이어 붙인다
   const children = block.has_children ? await getChildrenAsMarkdown(block.id) : "";

--- a/src/libs/notion/transformers.ts
+++ b/src/libs/notion/transformers.ts
@@ -214,6 +214,23 @@ n2m.setCustomTransformer("bookmark", (async (block: BlockObjectResponse) => {
   return `[${NOTION_BOOKMARK_MARKER}](${url})\n`;
 }) as CustomTransformer);
 
+// h4 헤딩 블록 변환 — heading_4는 Notion 2026-03 추가 블록이라
+// SDK 타입 union과 notion-to-md 기본 switch에 없어 커스텀 트랜스포머로 지원
+// (미등록 시 default 분기로 떨어져 헤딩이 일반 문단처럼 출력됨)
+n2m.setCustomTransformer("heading_4", (async (block: BlockObjectResponse) => {
+  const headingBlock = block as unknown as { heading_4: { rich_text: RichTextItemResponse[] } };
+  // 공백만 있는 헤딩이 빈 <h4>로 남지 않도록 trim
+  const text = richTextToMarkdown(headingBlock.heading_4.rich_text).trim();
+  // 커스텀 트랜스포머를 등록하면 n2m의 children 재귀가 꺼지므로(blocksToMarkdown의
+  // 재귀 가드) 토글 h4의 하위 블록은 callout과 같은 방식으로 직접 이어 붙인다
+  const children = block.has_children ? await getChildrenAsMarkdown(block.id) : "";
+
+  // 제목이 비면 헤딩은 생략하되 하위 블록 내용은 보존
+  if (!text) return children;
+
+  return children ? `#### ${text}\n\n${children}` : `#### ${text}`;
+}) as CustomTransformer);
+
 /**
  * 해당하는 페이지를 마크다운으로 변환하여 반환
  * @param pageId Notion 페이지 ID


### PR DESCRIPTION
## #️⃣ 연관 이슈

Closes #60

## 💻 작업 내용

Notion 2026-03 업데이트로 추가된 `heading_4` 블록이 `notion-to-md@3.1.9`의 default 분기로 떨어져 **일반 문단으로 강등 렌더**되던 문제를 커스텀 트랜스포머로 해결합니다.

- [x] `transformers.ts`에 `heading_4` 커스텀 트랜스포머 추가 — 표준 마크다운 `#### ` 방출 (센티넬 마커 불필요 → 렌더러·마커 상수·TOC 변경 없음)
- [x] 인라인 서식(볼드·링크·인라인 코드·수식) 보존 — 기존 `richTextToMarkdown` 재사용
- [x] **토글 h4 하위 블록 보존** — 커스텀 트랜스포머 등록 시 n2m의 children 재귀가 꺼지므로(`blocksToMarkdown` 재귀 가드) callout과 동일하게 `getChildrenAsMarkdown`으로 이어 붙임. 미처리 시 등록 전 대비 콘텐츠 소실 회귀 (셀프리뷰에서 발견, 스펙 결정 4에 근거 기록)
- [x] 공백뿐인 헤딩은 빈 `<h4>`로 남지 않도록 trim 후 생략 (토글 하위 내용은 보존)
- [x] 설계·계획 문서 (`docs/superpowers/specs·plans/2026-07-10-notion-h4-heading*`)

**캐시 레이어**: 4개 레이어 중 어느 것도 건드리지 않음 (마크다운 변환 로직만 변경 — dev Map 캐시는 변환 결과를 담지만 키·수명 불변).

### 테스트 결과 or 스크린샷 (선택)

테스트 러너가 없어 verify-before-pr 게이트로 검증:

- `pnpm exec tsc --noEmit` · `pnpm lint`(M-13 우회) · `pnpm build` 모두 통과
- 합성 블록 6케이스(일반/서식/빈/공백만/토글/빈제목 토글)를 n2m `blockToMarkdown`에 통과시켜 방출 마크다운 확인
- 실제 Upload 포스트("연봉 360만원짜리 시니어 개발자를 고용했습니다", h4 3개 포함)를 dev 서버에서 headless 브라우저로 확인:
  - h4 3개가 `<h4>` + prose 스타일로 렌더, 인라인 코드 서식 보존 (`<h4>… → <code>/code-review</code></h4>`)
  - NotionToc에 포함 + 앵커 id 부여, 다크모드 토글 후 콘솔 hydration 경고 0건, 375px 정상
  - 프로덕션 빌드 프리렌더 HTML에서도 h4 3개 확인
- 북 상세는 동일 트랜스포머(`getPageContentAsMarkdown`)를 공유하므로 별도 코드 경로 없음 (북 DB에 h4 콘텐츠 부재로 화면 확인은 생략, 근거: 렌더러도 동일하게 기본 h4 렌더)

스크린샷(라이트/다크/375px)은 로컬 캡처 완료 — 코멘트로 첨부 예정.

## 💬 리뷰 요구사항 (선택)

- n2m이 커스텀 트랜스포머 등록 타입의 children 재귀를 끈다는 사실(notion-to-md.js:202)이 토글 children 처리의 근거입니다. callout 트랜스포머와 같은 패턴인지 봐주세요.
- 375px에서 본문 마크다운 **테이블**이 뷰포트를 33px 넘치는 기존 이슈를 검증 중 발견 (h4와 무관, 별도 이슈로 다룰 예정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)