### PR TITLE
design: 인용문 좌측 바 높이를 텍스트에 맞게 수정

### DIFF
--- a/docs/superpowers/plans/2026-07-10-notion-quote-height.md
+++ b/docs/superpowers/plans/2026-07-10-notion-quote-height.md
@@ -1,0 +1,163 @@
+# Notion 인용문 세로 바 높이 정합 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 인용문(blockquote)의 좌측 브랜드색 세로 바가 본문 텍스트 높이에 정확히 맞게 한다.
+
+**Architecture:** 순수 CSS 수정. `prose.css`의 `.prose blockquote`에서 상하 padding을 제거하고, 첫/끝 문단의 상하 마진을 0으로 만드는 자식 셀렉터 규칙을 추가한다. 바(`border-l-4`)는 padding box까지 그려지므로 상하 padding·내부 문단 마진이 사라지면 텍스트 높이와 일치한다. prose.css는 블로그·북 레이아웃이 공유하므로 한 번에 둘 다 해결된다.
+
+**Tech Stack:** CSS (prose.css), 코드·컴포넌트 변경 없음
+
+## Global Constraints
+
+- 테스트 러너 없음 — 검증은 `pnpm exec tsc --noEmit` + `pnpm lint` + 브라우저 수동 확인 + `pnpm build` (CLAUDE.md)
+- worktree에서 `pnpm lint` 실패 시 M-13 우회: `.eslintrc.json`에 임시 `"root": true` 추가 → lint → `git checkout -- .eslintrc.json`
+- 커밋은 commit-message 스킬 형식: 한국어 제목, 마침표 없음, scope 없음, 본문 한 줄 40자 이내
+- 콜아웃(`aside.notion-callout`)·인용문 색상·폰트는 건드리지 않는다 (스펙 범위 밖)
+
+## File Structure
+
+| 파일                                                              | 변경 | 책임                                             |
+| ----------------------------------------------------------------- | ---- | ------------------------------------------------ |
+| `src/styles/prose.css`                                            | 수정 | blockquote 상하 padding 제거 + 첫/끝 문단 마진 0 |
+| `docs/superpowers/specs/2026-07-10-notion-quote-height-design.md` | 생성 | 설계 문서                                        |
+| `docs/superpowers/plans/2026-07-10-notion-quote-height.md`        | 생성 | 구현 계획 (이 문서)                              |
+
+---
+
+### Task 1: spec·plan 문서 커밋
+
+**Files:**
+
+- Create(이미 작성됨): `docs/superpowers/specs/2026-07-10-notion-quote-height-design.md`
+- Create(이미 작성됨): `docs/superpowers/plans/2026-07-10-notion-quote-height.md`
+
+**Interfaces:**
+
+- Consumes: 없음
+- Produces: 이후 Task의 근거 문서 (feature 브랜치 첫 커밋)
+
+- [ ] **Step 1: 두 문서를 feature 브랜치에 커밋**
+
+```bash
+git add docs/superpowers/specs/2026-07-10-notion-quote-height-design.md \
+        docs/superpowers/plans/2026-07-10-notion-quote-height.md
+git commit -m "docs: 인용문 바 높이 정합 설계·계획 문서 추가"
+```
+
+### Task 2: prose.css blockquote 수정
+
+**Files:**
+
+- Modify: `src/styles/prose.css:140-155` (인용구 스타일 블록)
+
+**Interfaces:**
+
+- Consumes: 없음 (독립 CSS)
+- Produces: `.prose blockquote` 스타일 — 두 레이아웃의 plain 인용문이 소비
+
+- [ ] **Step 1: 스타일 수정**
+
+기존:
+
+```css
+/* 인용구 스타일 */
+.prose blockquote {
+  @apply border-l-4 border-brand-400;
+  padding-left: 1.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.6;
+}
+
+.prose blockquote p {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+```
+
+변경 후:
+
+```css
+/* 인용구 스타일 — 좌측 바가 텍스트 높이에 맞도록 상하 padding 없음 */
+.prose blockquote {
+  @apply border-l-4 border-brand-400;
+  padding-left: 1.25rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.6;
+}
+
+.prose blockquote p {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+/* 첫/끝 문단의 바깥쪽 마진 제거 (문단 사이 간격은 유지) */
+.prose blockquote > p:first-child {
+  margin-top: 0;
+}
+
+.prose blockquote > p:last-child {
+  margin-bottom: 0;
+}
+```
+
+- [ ] **Step 2: 타입체크·린트**
+
+Run: `pnpm exec tsc --noEmit && pnpm lint`
+Expected: 둘 다 통과 (worktree에서 lint 실패 시 M-13 우회 적용)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/styles/prose.css
+git commit -m "design: 인용문 좌측 바 높이를 텍스트에 맞게 수정" -m "상하 padding과 첫/끝 문단 마진이
+바를 텍스트보다 길게 그리던 문제"
+```
+
+### Task 3: 엔드투엔드 수동 검증
+
+**Files:** 코드 변경 없음 (검증 전용)
+
+**Interfaces:**
+
+- Consumes: Task 2의 스타일, 인용문이 포함된 실제 포스트
+- Produces: PR 첨부용 스크린샷 + 검증 결과
+
+- [ ] **Step 1: 인용문 있는 포스트 확보**
+
+기존 Upload 포스트 중 quote 블록이 있는 글을 찾는다 (없으면 상황 보고 후 사용자에게 테스트 블록 추가 요청).
+
+- [ ] **Step 2: dev 서버에서 확인**
+
+Run: `pnpm dev` 후 해당 포스트 접속. 체크리스트:
+
+- 좌측 바 상단·하단이 텍스트 첫/끝 라인과 일치 (개발자도구 border box)
+- 다중 문단 인용에서 문단 사이 0.5rem 간격 유지
+- 인용 블록과 본문 사이 상하 간격(2rem) 유지
+- 콜아웃 렌더 무변화 (aside.notion-callout 별도 클래스)
+- 다크모드 토글 정상, 375px 정상, hydration 경고 0건
+
+- [ ] **Step 3: 프로덕션 빌드**
+
+Run: `pnpm build`
+Expected: 성공
+
+- [ ] **Step 4: 스크린샷 캡처**
+
+수정 후 라이트/다크 각 1장 — PR 본문 첨부용 (UI 변경이므로 필수)
+
+---
+
+## Self-Review
+
+- 스펙 커버리지: 결정 1·2(padding 제거+첫/끝 마진 0)→Task 2 Step 1, 결정 3(블록 간격 유지)→Task 3 체크리스트, 결정 4(콜아웃 무영향)→Task 3 체크리스트, 결정 5(블로그·북 공유)→Architecture 명시. 갭 없음.
+- 플레이스홀더: 없음 (기존/변경 CSS 전문, 명령·커밋 메시지 명시).
+- 타입 일관성: 신규 심볼 없음, 셀렉터 명칭 spec과 일치 (`> p:first-child`/`> p:last-child`).

--- a/docs/superpowers/specs/2026-07-10-notion-quote-height-design.md
+++ b/docs/superpowers/specs/2026-07-10-notion-quote-height-design.md
@@ -1,0 +1,66 @@
+# Notion 인용문 세로 바 높이 정합 — 설계
+
+날짜: 2026-07-10
+관련 작업: 인용문(quote) 블록의 좌측 바가 본문 텍스트보다 위아래로 튀어나오는 문제 수정
+
+## 배경
+
+Notion에서 `"`로 작성한 인용문(quote 블록)은 n2m 기본 변환으로 `> …` 마크다운이
+되고, `NotionBlockquote`가 콜아웃 마커가 없으면 plain `<blockquote>`로 렌더한다.
+`prose.css:140`의 `.prose blockquote`가 상하 `padding 0.75rem`을 주고, 내부
+`.prose blockquote p`가 상하 `margin 0.5rem`을 더해, 좌측 브랜드색 세로 바
+(`border-l-4`)가 **텍스트보다 위아래로 합계 ~1.25rem씩 길게** 그려진다.
+Notion 원본 스타일은 바가 텍스트 높이에 정확히 맞는다.
+
+## 결정 사항
+
+1. **수정 지점은 `src/styles/prose.css` 한 곳.** `.prose blockquote`의
+   `padding-top`/`padding-bottom`을 0으로 바꾸고, 첫/끝 문단의 상하 마진을
+   0으로 만드는 `>` 자식 셀렉터 규칙을 추가한다.
+2. **문단 사이 간격은 유지.** 다중 문단 인용에서 문단 간 0.5rem 간격은
+   그대로 두고, 첫 문단의 위쪽·마지막 문단의 아래쪽 마진만 제거한다
+   (`> p:first-child` / `> p:last-child`).
+3. **블록 바깥 간격(margin 2rem)은 유지.** margin은 border 바깥이라 바
+   길이에 영향이 없고, 본문과의 상하 간격 리듬은 보존한다.
+4. **콜아웃은 무영향.** 콜아웃은 `aside.notion-callout` 별도 클래스로
+   렌더되어 `.prose blockquote` 규칙을 타지 않는다.
+5. **블로그·북 동시 해결.** prose.css는 두 레이아웃(`NotionPostLayout`,
+   `BookPostLayout`)이 공유하는 `.prose` 스타일 원천이다.
+
+## 데이터 흐름
+
+```
+Notion quote 블록 → n2m 기본 "> …" → NotionBlockquote(마커 없음) → <blockquote>
+ → prose.css .prose blockquote (padding 상하 0, 첫/끝 문단 마진 0)
+ → 좌측 바가 텍스트 높이와 일치
+```
+
+## 구성 요소
+
+| 구성 요소                     | 변경 | 내용                                             |
+| ----------------------------- | ---- | ------------------------------------------------ |
+| `src/styles/prose.css`        | 수정 | blockquote 상하 padding 제거 + 첫/끝 문단 마진 0 |
+| `NotionBlockquote` / 레이아웃 | 없음 | 렌더 경로 그대로                                 |
+| `.notion-callout` 스타일      | 없음 | 별도 클래스, 무영향                              |
+
+## 에러 처리 · 폴백
+
+- 순수 CSS 변경으로 런타임 실패 경로 없음. 다중 문단·단일 문단·긴 줄바꿈
+  인용 모두 동일 규칙이 적용된다.
+
+## 테스트 · 검증
+
+1. `pnpm exec tsc --noEmit` + `pnpm lint` (worktree면 M-13 우회)
+2. 인용문이 있는 실제 포스트에서 `pnpm dev`로:
+   - 좌측 바 상단·하단이 텍스트 라인과 일치 (개발자도구로 border box 확인)
+   - 다중 문단 인용에서 문단 간 간격 유지
+   - 본문과 인용 블록 사이 상하 간격(2rem) 유지
+   - 콜아웃 렌더 무변화, 다크모드·375px 정상
+3. `pnpm build` 성공
+
+## 범위 밖 (YAGNI)
+
+- 인용문 색상·폰트·이탤릭 등 시각 스타일 변경 — 높이 정합만 다룬다.
+- 콜아웃(`aside.notion-callout`) 스타일 — 별도 클래스, 건드리지 않는다.
+- tailwind typography 설정의 blockquote 관련 항목 — prose.css가 원천이므로
+  중복 수정하지 않는다.

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -136,12 +136,10 @@
   margin-bottom: 0.5rem;
 }
 
-/* 인용구 스타일 */
+/* 인용구 스타일 — 좌측 바가 텍스트 높이에 맞도록 상하 padding 없음 */
 .prose blockquote {
   @apply border-l-4 border-brand-400;
   padding-left: 1.25rem;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
   margin-top: 2rem;
   margin-bottom: 2rem;
   font-style: normal;
@@ -152,6 +150,15 @@
 .prose blockquote p {
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
+}
+
+/* 첫/끝 문단의 바깥쪽 마진 제거 (문단 사이 간격은 유지) */
+.prose blockquote > p:first-child {
+  margin-top: 0;
+}
+
+.prose blockquote > p:last-child {
+  margin-bottom: 0;
 }
 
 .prose .notion-callout {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -152,12 +152,12 @@
   margin-bottom: 0.5rem;
 }
 
-/* 첫/끝 문단의 바깥쪽 마진 제거 (문단 사이 간격은 유지) */
-.prose blockquote > p:first-child {
+/* 첫/끝 자식의 바깥쪽 마진 제거 — p 외에 ul/pre 등도 커버 (사이 간격은 유지) */
+.prose blockquote > :first-child {
   margin-top: 0;
 }
 
-.prose blockquote > p:last-child {
+.prose blockquote > :last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
## #️⃣ 연관 이슈

Closes #62

## 💻 작업 내용

Notion quote 블록의 좌측 브랜드색 세로 바가 본문 텍스트보다 위아래로 ~1.25rem씩 튀어나오던 문제를 수정합니다.

- [x] 원인: `.prose blockquote`의 상하 `padding 0.75rem` + 내부 문단 상하 `margin 0.5rem` — `border-l-4` 바는 padding box까지 그려짐
- [x] `prose.css`에서 상하 padding 제거 + `> p:first-child`/`> p:last-child` 상하 마진 0 (문단 사이 0.5rem 간격과 블록 바깥 2rem 간격은 유지)
- [x] prose.css는 블로그·북 레이아웃 공용이므로 한 번에 둘 다 해결
- [x] 콜아웃(`aside.notion-callout`)은 별도 클래스로 무영향 확인

**캐시 레이어**: 4개 레이어 어느 것도 건드리지 않음 (순수 CSS).

### 테스트 결과 or 스크린샷 (선택)

- `tsc --noEmit` · `lint`(M-13 우회) · `build` 통과
- 실제 Upload 포스트(quote 4개, P+UL 복합 인용 포함)를 dev에서 headless 브라우저로 실측:
  - 4개 전부 바 상단·하단과 콘텐츠 첫/끝 라인의 gap **0px** (getBoundingClientRect 실측)
  - P+UL 구조 인용도 바가 리스트 마지막 항목까지 정확히 정합
  - 콜아웃 렌더 무변화, 다크모드 토글 후 콘솔 hydration 경고 0건, 375px 정상
- 캐스케이드 분석: 상하 padding·border가 없어 첫/끝 자식 마진이 blockquote 밖으로 collapse → 첫/끝 자식이 `ul`/`pre`여도 flush. 블록 바깥 간격은 `max(2rem, 자식 마진)` = 2rem으로 기존과 동일

스크린샷(라이트/다크/375px)은 로컬 캡처 완료 — 코멘트로 첨부 예정.

## 💬 리뷰 요구사항 (선택)

- `> p:first-child`/`> p:last-child` 규칙은 margin-collapse-through 때문에 기술적으로는 중복이지만, 의도 명시와 collapse가 깨지는 컨텍스트(향후 overflow/flow-root 등) 대비 보험으로 유지했습니다.
- 콜아웃 안에 중첩된 인용문(`> >`)도 같은 flush 스타일을 받게 되는데, 독립 인용문과 일관된 동작이라 의도된 방향으로 판단했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)