### PR TITLE
feat: RSS 피드 추가 및 sitemap lastmod 안정화

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -55,12 +55,13 @@ export async function POST(request: NextRequest) {
     // 기본적으로 노션 블로그 관련 경로들 재검증
     revalidatePath("/blog");
     revalidatePath("/api/notion/posts");
+    revalidatePath("/rss.xml");
 
     return NextResponse.json(
       {
         revalidated: true,
         now: Date.now(),
-        paths: [path, "/blog", "/api/notion/posts"].filter(Boolean),
+        paths: [path, "/blog", "/api/notion/posts", "/rss.xml"].filter(Boolean),
       },
       { status: 200 },
     );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import VisitorCounter from "../components/VisitorCounter";
 import { Analytics } from "@vercel/analytics/react";
 import { GoogleAnalytics, GoogleTagManager } from "@next/third-parties/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { RSS_PATH, SITE_NAME } from "../data/constants/site";
 
 export const viewport: Viewport = { width: "device-width", initialScale: 1 };
 
@@ -47,6 +48,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <GoogleTagManager gtmId="GTM-KJ94CWP4" />
       <GoogleAnalytics gaId="G-TDVKJ04GVC" />
       <body suppressHydrationWarning>
+        {/* RSS autodiscovery — 페이지별 metadata.alternates(canonical)가 루트 alternates.types를
+            얕은 병합으로 덮어쓰므로, React가 head로 호이스팅하는 link 태그로 전 페이지에 싣는다 */}
+        <link rel="alternate" type="application/rss+xml" title={SITE_NAME} href={RSS_PATH} />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,14 +1,13 @@
 import { MetadataRoute } from "next";
+import { SITE_URL } from "../data/constants/site";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = "https://blog.xuuno.me";
-
   return {
     rules: {
       userAgent: "*",
       allow: "/",
       disallow: "/api/",
     },
-    sitemap: `${baseUrl}/sitemap.xml`,
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,0 +1,72 @@
+import { RSS_PATH, SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "../../data/constants/site";
+import { getPublishedPageSummaries } from "../../libs/notion";
+
+// 캐시: Next ISR 레이어만 사용한다. on-demand /api/revalidate의 기본 갱신 목록에도 포함됨.
+export const revalidate = 3600;
+
+const MAX_FEED_ITEMS = 20;
+
+// XML 1.0에서 불법인 제어 문자는 이스케이프로도 살릴 수 없으므로 제거한다
+// (하나만 섞여도 엄격한 피드 파서가 피드 전체를 거부한다)
+function escapeXml(value: string): string {
+  return value
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g, "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// "YYYY-MM-DD" → RFC 822 형식 (RSS pubDate 규격). 파싱 불가 날짜는 생략한다.
+// 날짜만 있는 값은 UTC 자정으로 해석되면 하루가 밀려 보이므로 KST 자정으로 고정한다.
+function toPubDate(date: string): string | undefined {
+  const normalized = /^\d{4}-\d{2}-\d{2}$/.test(date) ? `${date}T00:00:00+09:00` : date;
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  return parsed.toUTCString();
+}
+
+export async function GET() {
+  // 조회 실패 시 getPublishedPageSummaries가 빈 배열을 반환하므로
+  // 피드 소비자에게는 글 없는 채널로 디그레이드된다 (5xx로 깨뜨리지 않음)
+  const posts = (await getPublishedPageSummaries()).slice(0, MAX_FEED_ITEMS);
+
+  const items = posts
+    .map((post) => {
+      const url = `${SITE_URL}/blog/${post.slug}`;
+      const pubDate = toPubDate(post.date);
+      return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>${
+        post.description
+          ? `
+      <description>${escapeXml(post.description)}</description>`
+          : ""
+      }${
+        pubDate
+          ? `
+      <pubDate>${pubDate}</pubDate>`
+          : ""
+      }
+    </item>`;
+    })
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(SITE_NAME)}</title>
+    <link>${SITE_URL}</link>
+    <description>${escapeXml(SITE_DESCRIPTION)}</description>
+    <language>ko</language>
+    <atom:link href="${SITE_URL}${RSS_PATH}" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: { "Content-Type": "application/rss+xml; charset=utf-8" },
+  });
+}

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,10 +1,12 @@
 import { RSS_PATH, SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "../../data/constants/site";
-import { getPublishedPageSummaries } from "../../libs/notion";
+import { getPublishedPageSummaries, type PageSummary } from "../../libs/notion";
+import { withTimeout } from "../../utils/with-timeout";
 
 // 캐시: Next ISR 레이어만 사용한다. on-demand /api/revalidate의 기본 갱신 목록에도 포함됨.
 export const revalidate = 3600;
 
 const MAX_FEED_ITEMS = 20;
+const RSS_FETCH_TIMEOUT_MS = 8000;
 
 // XML 1.0에서 불법인 제어 문자는 이스케이프로도 살릴 수 없으므로 제거한다
 // (하나만 섞여도 엄격한 피드 파서가 피드 전체를 거부한다)
@@ -28,9 +30,14 @@ function toPubDate(date: string): string | undefined {
 }
 
 export async function GET() {
-  // 조회 실패 시 getPublishedPageSummaries가 빈 배열을 반환하므로
-  // 피드 소비자에게는 글 없는 채널로 디그레이드된다 (5xx로 깨뜨리지 않음)
-  const posts = (await getPublishedPageSummaries()).slice(0, MAX_FEED_ITEMS);
+  // 조회 에러는 getPublishedPageSummaries가 빈 배열로 폴백하고,
+  // 응답 지연(hang)은 타임아웃으로 끊어 — 어느 쪽이든 5xx 대신 글 없는 채널로 디그레이드
+  let posts: PageSummary[] = [];
+  try {
+    posts = (await withTimeout(getPublishedPageSummaries(), RSS_FETCH_TIMEOUT_MS)).slice(0, MAX_FEED_ITEMS);
+  } catch (error) {
+    console.error("RSS 피드용 글 조회 타임아웃:", error);
+  }
 
   const items = posts
     .map((post) => {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,23 +1,10 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "../data/constants/site";
 import { getPublishedPageSummaries, getSitemapBookMetadata } from "../libs/notion";
+import { withTimeout } from "../utils/with-timeout";
 
 export const revalidate = 3600;
 const SITEMAP_FETCH_TIMEOUT_MS = 8000;
-
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-  const timeoutPromise = new Promise<T>((_, reject) => {
-    timeoutId = setTimeout(() => {
-      reject(new Error(`Sitemap generation timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-  });
-
-  return Promise.race([promise, timeoutPromise]).finally(() => {
-    if (timeoutId) clearTimeout(timeoutId);
-  });
-}
 
 // lastModified는 실제 콘텐츠 날짜가 있을 때만 싣는다 (undefined면 <lastmod> 미출력).
 // 재생성마다 new Date()를 넣으면 lastmod 신호 전체가 노이즈로 학습된다.

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
-import { getSitemapBookMetadata, getSitemapPageMetadata } from "../libs/notion";
+import { SITE_URL } from "../data/constants/site";
+import { getPublishedPageSummaries, getSitemapBookMetadata } from "../libs/notion";
 
 export const revalidate = 3600;
 const SITEMAP_FETCH_TIMEOUT_MS = 8000;
@@ -18,65 +19,68 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   });
 }
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = "https://blog.xuuno.me";
-  const currentDate = new Date().toISOString();
+// lastModified는 실제 콘텐츠 날짜가 있을 때만 싣는다 (undefined면 <lastmod> 미출력).
+// 재생성마다 new Date()를 넣으면 lastmod 신호 전체가 노이즈로 학습된다.
+function buildStaticPages(latestPostDate?: string, latestBookDate?: string): MetadataRoute.Sitemap {
+  // 홈은 최신 글·책 카드를 모두 노출하므로 둘 중 더 최근 날짜를 쓴다
+  const latestHomeDate = [latestPostDate, latestBookDate].filter(Boolean).sort().at(-1);
 
-  // 기본 정적 페이지들
-  const staticPages: MetadataRoute.Sitemap = [
+  return [
     {
-      url: baseUrl,
-      lastModified: currentDate,
+      url: SITE_URL,
+      lastModified: latestHomeDate,
       changeFrequency: "daily" as const,
       priority: 1.0,
     },
     {
-      url: `${baseUrl}/blog`,
-      lastModified: currentDate,
+      url: `${SITE_URL}/blog`,
+      lastModified: latestPostDate,
       changeFrequency: "daily" as const,
       priority: 0.95,
     },
     {
-      url: `${baseUrl}/book`,
-      lastModified: currentDate,
+      url: `${SITE_URL}/book`,
+      lastModified: latestBookDate,
       changeFrequency: "weekly" as const,
       priority: 0.9,
     },
     {
-      url: `${baseUrl}/about`,
-      lastModified: currentDate,
+      // about은 갱신 주기를 추적하지 않으므로 lastModified 생략
+      url: `${SITE_URL}/about`,
       changeFrequency: "monthly" as const,
       priority: 0.7,
     },
   ];
+}
 
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   try {
     const [pages, books] = await withTimeout(
-      Promise.all([getSitemapPageMetadata(), getSitemapBookMetadata()]),
+      Promise.all([getPublishedPageSummaries(), getSitemapBookMetadata()]),
       SITEMAP_FETCH_TIMEOUT_MS,
     );
 
-    const blogPages: MetadataRoute.Sitemap = pages
-      .filter((page) => Boolean(page.slug))
-      .map((page) => ({
-        url: `${baseUrl}/blog/${page.slug}`,
-        lastModified: page.date || currentDate,
-        changeFrequency: "weekly" as const,
-        priority: 0.8,
-      }));
+    const blogPages: MetadataRoute.Sitemap = pages.map((page) => ({
+      url: `${SITE_URL}/blog/${page.slug}`,
+      lastModified: page.date || undefined,
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+    }));
 
-    const bookPages: MetadataRoute.Sitemap = books
-      .filter((book) => Boolean(book.slug))
-      .map((book) => ({
-        url: `${baseUrl}/book/${book.slug}`,
-        lastModified: book.date || book.publishedAt || currentDate,
-        changeFrequency: "monthly" as const,
-        priority: 0.75,
-      }));
+    const bookPages: MetadataRoute.Sitemap = books.map((book) => ({
+      url: `${SITE_URL}/book/${book.slug}`,
+      lastModified: book.date || undefined,
+      changeFrequency: "monthly" as const,
+      priority: 0.75,
+    }));
+
+    // 쿼리 층위가 date 내림차순으로 정렬하므로 첫 유효 날짜가 최신이다
+    const staticPages = buildStaticPages(pages.find((page) => page.date)?.date, books.find((book) => book.date)?.date);
 
     return [...staticPages, ...blogPages, ...bookPages];
   } catch (error) {
     console.error("Error generating sitemap:", error);
-    return staticPages;
+    // 실패 시에도 거짓 lastmod를 싣지 않는다 (날짜 미상 = 생략)
+    return buildStaticPages();
   }
 }

--- a/src/data/constants/site.ts
+++ b/src/data/constants/site.ts
@@ -1,0 +1,7 @@
+// 사이트 원점·피드 계약 상수
+// 기계 소비 엔드포인트(robots·sitemap·rss)와 RSS autodiscovery 링크가 공유한다.
+// 페이지 메타데이터의 인라인 문자열들은 별개 관례이므로 일괄 통일하지 않는다 (M-4류).
+export const SITE_URL = "https://blog.xuuno.me";
+export const SITE_NAME = "Xperiences";
+export const SITE_DESCRIPTION = "프론트엔드 개발자의 실전 경험과 인사이트를 공유하는 기술 블로그";
+export const RSS_PATH = "/rss.xml";

--- a/src/libs/notion/books.ts
+++ b/src/libs/notion/books.ts
@@ -12,19 +12,29 @@ import { extractNotionBookData } from "./extractors";
 import { queryAllBooks, queryBookShelfPages } from "./queries";
 import { getPageContentAsMarkdown } from "./transformers";
 
-export type SitemapBookMetadata = Pick<BookMetadata, "slug" | "date" | "publishedAt">;
+// publishedAt(책 실물 출간일)은 페이지 갱신 시점과 무관하므로 sitemap lastmod에 싣지 않는다
+export type SitemapBookMetadata = Pick<BookMetadata, "slug" | "date">;
 
 /**
  * 사이트맵 생성용 경량 책 메타데이터 조회
+ * - 정렬은 쿼리 층위(queryAllBooks)의 date 내림차순을 그대로 신뢰한다.
+ * - 쿼리 층위와 별개로 Upload 게이트를 한 번 더 검사한다 (M-10 이중 게이트).
  */
 export async function getSitemapBookMetadata(): Promise<SitemapBookMetadata[]> {
   try {
     const pages = await queryAllBooks();
-    return pages.map((page) => {
-      const { slug, date, publishedAt } = extractNotionBookData(page);
-      return { slug, date, publishedAt };
+    return pages.flatMap((page) => {
+      // 한 페이지의 프로퍼티 이상이 목록 전체를 비우지 않도록 페이지 단위로 격리
+      try {
+        const { slug, date, status } = extractNotionBookData(page);
+        return status === "Upload" && slug ? [{ slug, date }] : [];
+      } catch (error) {
+        console.error(`책 요약 추출 실패 (${page.id}):`, error);
+        return [];
+      }
     });
   } catch (error) {
+    // list 계열이지만 소비자(sitemap)를 깨뜨리지 않도록 빈 목록으로 폴백 (M-14 선택)
     console.error("사이트맵용 책 메타데이터 조회 실패:", error);
     return [];
   }

--- a/src/libs/notion/index.ts
+++ b/src/libs/notion/index.ts
@@ -11,4 +11,4 @@ export {
 
 export { getCategories, getCategoriesWithUploadedPosts } from "./categories";
 
-export { getAllPageMetadata, getPostDetail, getSitemapPageMetadata, type SitemapPageMetadata } from "./posts";
+export { getAllPageMetadata, getPostDetail, getPublishedPageSummaries, type PageSummary } from "./posts";

--- a/src/libs/notion/posts.ts
+++ b/src/libs/notion/posts.ts
@@ -13,7 +13,7 @@ import { getPlainText, getProperty, getStatus } from "./properties";
 import { queryAllPages } from "./queries";
 import { getPageContentAsMarkdown } from "./transformers";
 
-export type SitemapPageMetadata = Pick<PageMetadata, "slug" | "date">;
+export type PageSummary = Pick<PageMetadata, "title" | "slug" | "description" | "date">;
 
 /**
  * 관계 페이지 ID를 받아 참조 정보를 반환하는 함수
@@ -55,18 +55,27 @@ async function getRelatedPosts(prevPageId: string, nextPageId: string): Promise<
 }
 
 /**
- * 사이트맵 생성용 경량 페이지 메타데이터 조회
- * - 상세/연관 포스트 조회를 생략해 타임아웃 위험을 줄인다.
+ * 발행(Upload) 글의 경량 요약 조회 — sitemap·RSS 공용
+ * - 상세/연관 포스트 조회를 생략해 타임아웃·재생성 비용을 줄인다.
+ * - 정렬은 쿼리 층위(queryAllPages)의 date 내림차순을 그대로 신뢰한다.
+ * - 쿼리 층위와 별개로 Upload 게이트를 한 번 더 검사한다 (M-10 이중 게이트).
  */
-export async function getSitemapPageMetadata(): Promise<SitemapPageMetadata[]> {
+export async function getPublishedPageSummaries(): Promise<PageSummary[]> {
   try {
     const pages = await queryAllPages();
-    return pages.map((page) => {
-      const { slug, date } = extractNotionRawData(page);
-      return { slug, date };
+    return pages.flatMap((page) => {
+      // 한 페이지의 프로퍼티 이상(빈 rollup 등)이 목록 전체를 비우지 않도록 페이지 단위로 격리
+      try {
+        const { title, slug, description, date, status } = extractNotionRawData(page);
+        return status === "Upload" && slug ? [{ title, slug, description, date }] : [];
+      } catch (error) {
+        console.error(`페이지 요약 추출 실패 (${page.id}):`, error);
+        return [];
+      }
     });
   } catch (error) {
-    console.error("사이트맵용 페이지 메타데이터 조회 실패:", error);
+    // list 계열이지만 소비자(sitemap·RSS)를 깨뜨리지 않도록 빈 목록으로 폴백 (M-14 선택)
+    console.error("발행 글 요약 조회 실패:", error);
     return [];
   }
 }

--- a/src/utils/with-timeout.ts
+++ b/src/utils/with-timeout.ts
@@ -1,0 +1,15 @@
+// 외부 API(Notion 등) 호출이 응답 없이 지연될 때 플랫폼 함수 타임아웃(504)까지
+// 끌려가지 않도록 제한 시간을 강제한다. sitemap·RSS 재생성 경로에서 공용.
+export function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<T>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(`Operation timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeoutId) clearTimeout(timeoutId);
+  });
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈

Closes #64

## 💻 작업 내용

- [x] `sitemap.ts`: 정적 페이지 lastModified를 실제 콘텐츠 날짜 기반으로 변경 (`new Date()` 노이즈 제거, 홈은 최신 글·책 중 더 최근 날짜, `/about`은 생략)
- [x] 글/책 항목의 currentDate 폴백 제거 — 날짜 없으면 lastModified 생략 (거짓 신호보다 무신호)
- [x] book의 `publishedAt`(도서 실물 출간일)을 lastmod에서 제외
- [x] `app/rss.xml/route.ts`: 발행(Upload) 글 RSS 2.0 피드 추가 — 의존성 없음, 최신 20개, XML 불법 제어문자 제거, 날짜만 있는 pubDate는 KST 자정 기준
- [x] sitemap·RSS 공용 `getPublishedPageSummaries` 도입 — Upload 이중 게이트(M-10), 페이지 단위 오류 격리(글 1개의 프로퍼티 이상이 목록 전체를 비우지 않음)
- [x] 기계 소비 엔드포인트(robots·sitemap·rss) 공용 `SITE_URL` 등 상수 분리
- [x] `layout.tsx`: RSS autodiscovery link 태그 — 페이지별 `alternates`(canonical)가 루트 `alternates.types`를 얕은 병합으로 덮어써서, React 19 head 호이스팅 방식으로 전 페이지 적용
- [x] `/api/revalidate` 기본 갱신 목록에 `/rss.xml` 추가 (캐시: Next ISR 레이어 + on-demand 커버)

### 테스트 결과 or 스크린샷 (선택)

- `pnpm exec tsc --noEmit` ✅ / `pnpm lint` ✅ (worktree root:true 우회) / `pnpm build` ✅ (30/30 페이지, /rss.xml·/sitemap.xml 1h revalidate)
- dev에서 `/rss.xml` 실제 응답 확인: xmllint 유효성 통과, Content-Type `application/rss+xml`, pubDate KST 자정 기준(`Thu, 09 Jul 2026 15:00:00 GMT` = 7/10 00:00 KST)
- `/sitemap.xml`: 홈·/blog lastmod=최신 글(2026-07-10), /book=최신 책(2026-05-30), /about lastmod 없음 확인
- autodiscovery link가 `/`·`/blog`·글 상세 `<head>` 안에 렌더되는 것 확인

## 💬 리뷰 요구사항 (선택)

의도된 결정 (버그 아님):
- lastmod는 발행일(date) 기준 — `last_edited_time`은 사소한 터치에도 갱신되어 노이즈를 재도입하므로 채택하지 않음
- RSS 조회 실패 시 5xx 대신 빈 채널로 디그레이드 (M-14에서 피드 소비자 보호 선택, 주석 명시)
- RSS는 글만 포함 (책 제외 — YAGNI)
- Notion 장애 시 sitemap이 정적 4페이지(lastmod 생략)로 축소되는 것은 기존 동작 유지