### PR TITLE
feat: 네이버 서치어드바이저 소유 확인 메타 태그 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,6 +40,10 @@ export const metadata: Metadata = {
   authors: [{ name: "jjunohj", url: "https://github.com/jjunohj" }],
   creator: "jjunohj",
   publisher: "Xperiences",
+  // 네이버 서치어드바이저 사이트 소유 확인 (공개 무해 토큰)
+  verification: {
+    other: { "naver-site-verification": "79995699dc20b9f4c810a4088ff8d0934d46e62c" },
+  },
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## #️⃣ 연관 이슈

Closes #66

## 💻 작업 내용

- [x] `layout.tsx` metadata `verification.other`에 `naver-site-verification` 추가

### 테스트 결과 or 스크린샷 (선택)

- `pnpm exec tsc --noEmit` ✅ / `pnpm lint` ✅ (worktree root:true 우회) / `pnpm build` ✅ (30/30)
- dev에서 `/`·`/blog`·글 상세·`/book`·`/about` 전부 `<head>` 안에 메타 태그 렌더 확인
  (페이지별 metadata 정의가 있는 페이지에서도 verification 키는 덮어써지지 않음을 실측)

## 💬 리뷰 요구사항 (선택)

- 토큰은 HTML에 공개 노출되는 무해한 값이라 하드코딩했습니다 (env 분리 불필요)
- 머지·배포 후 네이버 서치어드바이저에서 소유 확인 버튼 클릭은 사용자 액션