### PR TITLE
design: 책 카드 표지 크롭 제거 (#68)

### DIFF
--- a/src/app/book/_components/BookCard.tsx
+++ b/src/app/book/_components/BookCard.tsx
@@ -70,12 +70,14 @@ export default function BookCard({ book }: BookCardProps) {
         />
 
         <div className="absolute inset-0 flex items-center justify-center p-6">
-          <div className="relative h-full w-32 overflow-hidden border border-neutral-300 bg-neutral-200 shadow-[0_14px_20px_-12px_rgba(0,0,0,0.6)] dark:border-neutral-600 dark:bg-neutral-700">
+          {/* 표지는 원본 비율 유지 — 고정 프레임 + object-cover는 비율이 어긋나면 상단이 잘린다 (#68) */}
+          <div className="relative h-full max-w-full">
             <Image
               src={book.cover || "/og-image.png"}
               alt={book.title || "도서 커버"}
-              fill
-              className="object-cover transition duration-300 group-hover:scale-[1.01]"
+              width={0}
+              height={0}
+              className="h-full w-auto max-w-full border border-neutral-300 bg-neutral-200 object-contain shadow-[0_14px_20px_-12px_rgba(0,0,0,0.6)] transition duration-300 group-hover:scale-[1.01] dark:border-neutral-600 dark:bg-neutral-700"
               sizes="128px"
             />
             <div className="bg-black/18 absolute left-0 top-0 h-full w-[6px]" />

--- a/src/app/book/_components/BookCard.tsx
+++ b/src/app/book/_components/BookCard.tsx
@@ -77,8 +77,8 @@ export default function BookCard({ book }: BookCardProps) {
               alt={book.title || "도서 커버"}
               width={0}
               height={0}
-              className="h-full w-auto max-w-full border border-neutral-300 bg-neutral-200 object-contain shadow-[0_14px_20px_-12px_rgba(0,0,0,0.6)] transition duration-300 group-hover:scale-[1.01] dark:border-neutral-600 dark:bg-neutral-700"
-              sizes="128px"
+              className="h-full w-auto max-w-full border border-neutral-300 bg-neutral-200 object-contain shadow-[0_14px_20px_-12px_rgba(0,0,0,0.6)] transition duration-300 [aspect-ratio:auto_2/3] group-hover:scale-[1.01] dark:border-neutral-600 dark:bg-neutral-700"
+              sizes="160px"
             />
             <div className="bg-black/18 absolute left-0 top-0 h-full w-[6px]" />
           </div>

--- a/src/components/notion/NotionBookCard.tsx
+++ b/src/components/notion/NotionBookCard.tsx
@@ -54,8 +54,8 @@ export default function NotionBookCard({ book }: NotionBookCardProps) {
                   width={0}
                   height={0}
                   draggable={false}
-                  sizes="128px"
-                  className="h-full w-auto max-w-full border border-neutral-300 bg-neutral-200 object-contain shadow-[0_14px_20px_-12px_rgba(0,0,0,0.6)] transition-transform duration-300 group-hover:scale-[1.02] dark:border-neutral-600 dark:bg-neutral-700"
+                  sizes="160px"
+                  className="h-full w-auto max-w-full border border-neutral-300 bg-neutral-200 object-contain shadow-[0_14px_20px_-12px_rgba(0,0,0,0.6)] transition-transform duration-300 [aspect-ratio:auto_2/3] group-hover:scale-[1.02] dark:border-neutral-600 dark:bg-neutral-700"
                 />
                 <div className="absolute left-0 top-0 h-full w-[6px] bg-black/[0.18]" />
               </div>

--- a/src/components/notion/NotionBookCard.tsx
+++ b/src/components/notion/NotionBookCard.tsx
@@ -46,14 +46,16 @@ export default function NotionBookCard({ book }: NotionBookCardProps) {
           {/* 중앙 표지 영역 (남는 공간 차지) */}
           <div className="relative z-10 flex flex-1 items-center justify-center p-5 sm:p-6">
             {book.cover ? (
-              <div className="relative aspect-[2/3] h-32 overflow-hidden border border-neutral-300 bg-neutral-200 shadow-[0_14px_20px_-12px_rgba(0,0,0,0.6)] transition-transform duration-300 group-hover:scale-[1.02] dark:border-neutral-600 dark:bg-neutral-700 sm:h-48">
+              /* 표지는 원본 비율 유지 — 고정 프레임 + object-cover는 비율이 어긋나면 잘린다 (#68) */
+              <div className="relative h-32 max-w-full sm:h-48">
                 <Image
                   src={book.cover}
                   alt={book.title}
-                  fill
+                  width={0}
+                  height={0}
                   draggable={false}
                   sizes="128px"
-                  className="object-cover"
+                  className="h-full w-auto max-w-full border border-neutral-300 bg-neutral-200 object-contain shadow-[0_14px_20px_-12px_rgba(0,0,0,0.6)] transition-transform duration-300 group-hover:scale-[1.02] dark:border-neutral-600 dark:bg-neutral-700"
                 />
                 <div className="absolute left-0 top-0 h-full w-[6px] bg-black/[0.18]" />
               </div>


### PR DESCRIPTION
## #️⃣ 연관 이슈

Closes #68

## 💻 작업 내용

- [x] `BookCard`(/book): 표지 프레임의 고정 크기(`h-full w-32`, 비율 0.727)를 제거하고 표지가 원본 비율대로 높이에 맞춰 서도록 변경 (`width/height={0}` + `h-full w-auto object-contain`)
- [x] `NotionBookCard`(홈 Readings): 동일 패턴 적용 — 두 화면의 표지 렌더 일치
- [x] 테두리·그림자·책등(spine) 오버레이·호버 스케일을 이미지 실제 박스로 이동
- [x] 가로형 폴백 이미지(og-image) 대비 `max-w-full` 가드

### 테스트 결과 or 스크린샷 (선택)

- tsc ✅ / lint ✅ (worktree root:true 우회) / build ✅ (30/30)
- headless 브라우저 실측: /book 라이트·다크·375px, 홈 Readings 탭 — 표지 상단 제목부까지 전체 표시 확인, 375px 오버플로 없음, **콘솔 hydration 경고 0건**
- 스크린샷은 로컬 캡처본이 있으며 필요 시 코멘트로 첨부 예정 (headless 캡처: book-light/book-mobile(dark)/home-readings)

## 💬 리뷰 요구사항 (선택)

- 진단 근거: 실제 표지 비율 0.685·0.715 vs 기존 /book 프레임 0.727 → object-cover 중앙 크롭으로 위아래 ~6% 잘림
- 표지 폭이 이제 책마다 미세하게 달라집니다(원본 비율 반영) — 의도된 변화